### PR TITLE
Testing PR Events

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: automated release
 
-# Trigger whenever branch receives new commit
+# Trigger whenever branch receives new commit (from PR merge or regular Push)
 on:
   push:
     branches:
@@ -40,10 +40,11 @@ jobs:
         git merge origin/test-review
         npm run build
         git add .
-        git commit -m "Add built files"
+        git commit -m "Built on `date +'%Y-%m-%d %H:%M:%S'`"
     - name: push changes
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: test-master
+        # has to force because master will always have a split at HEAD
         force: true


### PR DESCRIPTION
[Reference](https://help.github.com/en/articles/events-that-trigger-workflows#pull-request-event-pull_request)
`test.yml` should only trigger on `opened`, `synchronized`, `reopened`

checking the following activity types do not trigger `test.yml`
- [x] assigned
- [x] unassigned
- [x] labeled
- [x] unlabeled
- [x] edited
- [x] closed
- [ ] ready_for_review
- [x] locked
- [x] unlocked
- [ ] review_requested
- [ ] review_request_removed